### PR TITLE
[Deprecated by #27] Observe keyboard presentation and dismissal

### DIFF
--- a/Presentr.xcodeproj/project.pbxproj
+++ b/Presentr.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		06B5855F1D2D6FE20045C8DA /* ModalCenterPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B5855E1D2D6FE20045C8DA /* ModalCenterPosition.swift */; };
 		06BE3E4C1CED58DB0052424E /* SourceSansPro-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 06BE3E4B1CED58DB0052424E /* SourceSansPro-Regular.ttf */; };
 		06BE3E4E1CED58EA0052424E /* Montserrat-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 06BE3E4D1CED58EA0052424E /* Montserrat-Regular.ttf */; };
+		283CE2321D3980EE008E5E0F /* KeyboardTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283CE2311D3980EE008E5E0F /* KeyboardTranslation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		06B5855E1D2D6FE20045C8DA /* ModalCenterPosition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalCenterPosition.swift; sourceTree = "<group>"; };
 		06BE3E4B1CED58DB0052424E /* SourceSansPro-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Regular.ttf"; sourceTree = "<group>"; };
 		06BE3E4D1CED58EA0052424E /* Montserrat-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Montserrat-Regular.ttf"; sourceTree = "<group>"; };
+		283CE2311D3980EE008E5E0F /* KeyboardTranslation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardTranslation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +117,7 @@
 				06B585571D2D6F4B0045C8DA /* PresentationType.swift */,
 				06B5855A1D2D6F8B0045C8DA /* TransitionType.swift */,
 				06B5855C1D2D6FB00045C8DA /* ModalSize.swift */,
+				283CE2311D3980EE008E5E0F /* KeyboardTranslation.swift */,
 				06B5855E1D2D6FE20045C8DA /* ModalCenterPosition.swift */,
 				06686CB41CE96DCE00F88216 /* Animation */,
 				06D8AE8E1CE40BF300E00A6C /* Alert */,
@@ -275,6 +278,7 @@
 				06B5855B1D2D6F8B0045C8DA /* TransitionType.swift in Sources */,
 				06B5855F1D2D6FE20045C8DA /* ModalCenterPosition.swift in Sources */,
 				06686C9D1CE947E200F88216 /* CoverHorizontalAnimation.swift in Sources */,
+				283CE2321D3980EE008E5E0F /* KeyboardTranslation.swift in Sources */,
 				0680CC4D1CE3EFC500CBAE4F /* Presentr.swift in Sources */,
 				0680CC541CE3EFFA00CBAE4F /* AlertViewController.swift in Sources */,
 				0680CC4F1CE3EFC500CBAE4F /* PresentrController.swift in Sources */,

--- a/Presentr/KeyboardTranslation.swift
+++ b/Presentr/KeyboardTranslation.swift
@@ -17,23 +17,20 @@ public enum KeyboardTranslationType {
     case None, MoveUp, Compress
     
     public static func getTranslationFrame (type : KeyboardTranslationType, keyboardFrame : CGRect, presentedFrame : CGRect) -> CGRect {
+        let keyboardTop = UIScreen.mainScreen().bounds.height - keyboardFrame.size.height
+        let presentedViewBottom = presentedFrame.origin.y + presentedFrame.height + 20 // add a 20 pt buffer
+        let offset = presentedViewBottom - keyboardTop
         switch type {
         case MoveUp:
-            let keyboardTop = UIScreen.mainScreen().bounds.height - keyboardFrame.size.height
-            let presentedViewBottom = presentedFrame.origin.y + presentedFrame.height + 20 // add a 20 pt buffer
-            let offset = presentedViewBottom - keyboardTop
-            print(offset)
             if offset > 0 {
                 return CGRectMake(presentedFrame.origin.x, presentedFrame.origin.y-offset, presentedFrame.size.width, presentedFrame.size.height)
             }
             return presentedFrame
         case Compress:
-            let keyboardTop = UIScreen.mainScreen().bounds.height - keyboardFrame.size.height
-            let presentedViewBottom = presentedFrame.origin.y + presentedFrame.height + 20 // add a 20 pt buffer
-            let offset = presentedViewBottom - keyboardTop
-            print(offset)
             if offset > 0 {
-                return CGRectMake(presentedFrame.origin.x, max(presentedFrame.origin.y-offset, presentedFrame.origin.y+20), presentedFrame.size.width, presentedFrame.size.height)
+                let y = max(presentedFrame.origin.y-offset, 20)
+                let frame = CGRectMake(presentedFrame.origin.x, y, presentedFrame.size.width, y != 20 ? presentedFrame.size.height : keyboardTop - 40)
+                return frame
             }
             return presentedFrame
         case None:

--- a/Presentr/KeyboardTranslation.swift
+++ b/Presentr/KeyboardTranslation.swift
@@ -1,0 +1,43 @@
+//
+//  KeyboardTranslation.swift
+//  Presentr
+//
+//  Created by Aaron Satterfield on 7/15/16.
+//  Copyright © 2016 danielozano. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public protocol PresentrKeyboardDelegate {
+    func shouldDismissKeyboard();
+}
+
+public enum KeyboardTranslationType {
+    case None, MoveUp, Compress
+    
+    public static func getTranslationFrame (type : KeyboardTranslationType, keyboardFrame : CGRect, presentedFrame : CGRect) -> CGRect {
+        switch type {
+        case MoveUp:
+            let keyboardTop = UIScreen.mainScreen().bounds.height - keyboardFrame.size.height
+            let presentedViewBottom = presentedFrame.origin.y + presentedFrame.height + 20 // add a 20 pt buffer
+            let offset = presentedViewBottom - keyboardTop
+            print(offset)
+            if offset > 0 {
+                return CGRectMake(presentedFrame.origin.x, presentedFrame.origin.y-offset, presentedFrame.size.width, presentedFrame.size.height)
+            }
+            return presentedFrame
+        case Compress:
+            let keyboardTop = UIScreen.mainScreen().bounds.height - keyboardFrame.size.height
+            let presentedViewBottom = presentedFrame.origin.y + presentedFrame.height + 20 // add a 20 pt buffer
+            let offset = presentedViewBottom - keyboardTop
+            print(offset)
+            if offset > 0 {
+                return CGRectMake(presentedFrame.origin.x, max(presentedFrame.origin.y-offset, presentedFrame.origin.y+20), presentedFrame.size.width, presentedFrame.size.height)
+            }
+            return presentedFrame
+        case None:
+            return presentedFrame
+        }
+    }
+}

--- a/Presentr/ModalCenterPosition.swift
+++ b/Presentr/ModalCenterPosition.swift
@@ -55,5 +55,4 @@ public enum ModalCenterPosition {
             return nil
         }
     }
-    
 }

--- a/Presentr/PresentationType.swift
+++ b/Presentr/PresentationType.swift
@@ -76,3 +76,4 @@ public enum PresentationType {
     }
     
 }
+

--- a/Presentr/Presentr.swift
+++ b/Presentr/Presentr.swift
@@ -43,7 +43,7 @@ public class Presentr: NSObject {
     public var observeKeyboard = false
     
     /// How the presented view controller should respond in response to keyboard presentation.
-    let keyboardTranslationType: KeyboardTranslationType = .None
+    public var keyboardTranslationType: KeyboardTranslationType = .None
     
     // MARK: Private Helper Var's
     

--- a/Presentr/Presentr.swift
+++ b/Presentr/Presentr.swift
@@ -20,9 +20,6 @@ struct PresentrConstants {
     }
 }
 
-public protocol PresentrKeyboardDelegate {
-    func shouldDismissKeyboard();
-}
 
 /// Main Presentr class. This is the point of entry for using the framework.
 public class Presentr: NSObject {
@@ -41,6 +38,12 @@ public class Presentr: NSObject {
     
     /// Should the presented controller dismiss on background tap. Default is true.
     public var dismissOnTap = true
+    
+    /// Should the presenter controller observe the showing and dismissal of the keyboard. Default is false. Only avaiable Popup Presentation Type. for Use this when you have a text field or text view in the presented controller to use taps on the outside of the controller to dismiss the keyboard instead of dismissing the controller. Also translates the view controller based on the keyboard offset if part of the view would be covered by the keyboard.
+    public var observeKeyboard = false
+    
+    /// How the presented view controller should respond in response to keyboard presentation.
+    let keyboardTranslationType: KeyboardTranslationType = .None
     
     // MARK: Private Helper Var's
     
@@ -127,7 +130,9 @@ extension Presentr: UIViewControllerTransitioningDelegate{
                                                         presentingViewController: presenting,
                                                         presentationType: presentationType,
                                                         roundCorners: roundCorners,
-                                                        observeKeyboard: observeKeyboard)
+                                                        dismissOnTap: dismissOnTap,
+                                                        observeKeyboard: observeKeyboard,
+                                                        keyboardTranslationType: keyboardTranslationType)
         return presentationController
     }
     

--- a/Presentr/PresentrController.swift
+++ b/Presentr/PresentrController.swift
@@ -194,6 +194,7 @@ extension PresentrController {
     }
 
     override func containerViewWillLayoutSubviews() {
+        guard keyboardIsShowing == false else { return }
         chromeView.frame = containerView!.bounds
         presentedView()!.frame = frameOfPresentedViewInContainerView()
     }

--- a/PresentrExample/PresentrExample/Base.lproj/Main.storyboard
+++ b/PresentrExample/PresentrExample/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>

--- a/README.md
+++ b/README.md
@@ -31,11 +31,9 @@ pod 'Presentr'
 1. Download and drop ```/Presentr``` folder in your project.  
 2. Congratulations! 
 
-## Usage
+## Main Types
 
-### Main Types
-
-#### Presentation Type
+### Presentation Type
 
 ```swift
 public enum PresentationType {
@@ -46,14 +44,14 @@ public enum PresentationType {
   case Custom(width: ModalSize, height: ModalSize, center: ModalCenterPosition)
 }
 ```
-##### Alert & Popup
+#### Alert & Popup
 <img src="http://danielozano.com/PresentrScreenshots/Alert1.png" width="250">
 <img src="http://danielozano.com/PresentrScreenshots/Popup1.png" width="250">
-##### BottomHalf & TopHalf
+#### BottomHalf & TopHalf
 <img src="http://danielozano.com/PresentrScreenshots/BottomHalf1.png" width="250">
 <img src="http://danielozano.com/PresentrScreenshots/TopHalf2.png" width="250">
 
-#### Transition Type
+### Transition Type
 
 ```swift
 public enum TransitionType{
@@ -68,9 +66,9 @@ public enum TransitionType{
 }
 ```
 
-### Getting Started
+## Getting Started
 
-#### Create a Presentr object
+### Create a Presentr object
 
 It is **important to hold on to the Presentr object as a property** on the presenting/current View Controller since internally it will be used as a delegate for the custom presentation, so you must hold a strong reference to it.
 
@@ -92,7 +90,7 @@ The PresentationType (and all other properties) can be changed later on in order
 presenter.presentationType = .Popup
 ```
 
-#### Properties (These are optional, as they all have Default values)
+### Properties (These are optional, as they all have Default values)
 
 You can choose a TransitionType, which is the animation that will be used to present or dismiss the view controller. 
 
@@ -113,7 +111,7 @@ You can choose to disable dismissOnTap that dismisses the presented view control
 presenter.dismissOnTap = false
 ```
 
-#### Present the view controller.
+### Present the view controller.
 
 Instantiate the View Controller you want to present. Remember to setup autolayout on it so it can be displayed well on any size.
 
@@ -124,7 +122,7 @@ customPresentViewController(presenter, viewController: controller, animated: tru
 
 This is a helper method provided for you as an extension on UIViewController. It handles setting the Presentr object as the delegate for the presentation & transition. 
 
-#### Creating a custom PresentationType
+### Creating a custom PresentationType
 
 If you need to present a controller in a way that is not handled by the 4 included presentation types you can create your own. You create a custom **PresentationType** using the **.Custom** case on the **PresentationType** enum.
 ```swift 
@@ -197,7 +195,7 @@ class ViewController: UIViewController{
 
 <img src="http://danielozano.com/PresentrScreenshots/CustomPresentationType.png" width="250">
 
-#### Presentr also comes with a cool AlertViewController baked in if you want something different from Apple's. The API is very similar to Apple's alert controller.
+### Presentr also comes with a cool AlertViewController baked in if you want something different from Apple's. The API is very similar to Apple's alert controller.
 
 ```swift
 


### PR DESCRIPTION
For use when presented controller is presented as a popup. Use case for
when user has a text field and doesn’t want the keyboard to cover the
bottom part of the presented view which would normally contain some
kind of button.

The view also won't dismiss on the tap of the container view when the keyboard is being shown. Instead, it will simply dismiss the keyboard. Added 'PresentrKeyboardDelegate' that has 'shouldDismissKeyboard' to which the presented view controller can conform to. This will notify that controller of the tap on the container so it can dismiss the keyboard

Added 'KeyboardTranslationType' with '.MoveUp', '.Compress', '.None'. Move up will simply translate the view up on the y axis. Compress compresses the view between the keyboard and the status bar. 