### PR TITLE
Add support for animated blurred chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### What's New
 
 #### 1.0.4
-- Support animated blurred background (thanks to @fpg1503)
+- Support for animated blurred background (thanks to @fpg1503)
 
 #### 1.0.3
 - Support for custom radius & drop shadow (thanks @falkobuttler)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### What's New
 
+#### 1.0.4
+- Support animated blurred background (thanks to @fpg1503)
+
 #### 1.0.3
 - Support for custom radius & drop shadow (thanks @falkobuttler)
 - New fluid percentage option for ModalSize enum (thanks @mseijas)

--- a/Presentr.podspec
+++ b/Presentr.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Presentr"
-  s.version      = "1.0.3"
+  s.version      = "1.0.4"
   s.summary      = "A simple Swift wrapper for typical custom view controller presentations."
   s.description  = <<-DESC
                     A micro framework created in Swift. Simplifies creating custom view controller presentations. Specially the typical ones we use which are a popup, an alert, or a any non-full-screen modal. Abstracts having to deal with custom presentation controllers and transitioning delegates
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author       = { "Daniel Lozano" => "dan@danielozano.com" }
   s.social_media_url   = "http://twitter.com/danlozanov"
   s.platform     = :ios, "9.0"
-  s.source       = { :git => "https://github.com/icalialabs/Presentr.git", :tag => "1.0.3" }
+  s.source       = { :git => "https://github.com/icalialabs/Presentr.git", :tag => "1.0.4" }
   s.source_files = "Presentr/**/*.{swift}"
   s.resources    = "Presentr/**/*.{xib,ttf}"
 end

--- a/Presentr/ModalSize.swift
+++ b/Presentr/ModalSize.swift
@@ -16,7 +16,7 @@ import Foundation
  - Full:        Full screen.
  - Custom:      Custom fixed size.
  - Fluid:       Custom percentage-based fluid size.
- - SideMargin:  Custom value for margins
+ - SideMargin:  Uses side margins to calculate size.
  */
 public enum ModalSize {
 
@@ -47,7 +47,7 @@ public enum ModalSize {
         case .fluid(let percentage):
             return floorf(Float(parentSize.width) * percentage)
         case .sideMargin(let value):
-            return floorf(Float(parentSize.width) - value * 2)
+            return floorf(Float(parentSize.width) - value * 2.0)
         }
     }
 

--- a/Presentr/PresentrController.swift
+++ b/Presentr/PresentrController.swift
@@ -61,6 +61,7 @@ class PresentrController: UIPresentationController, UIAdaptivePresentationContro
     }
 
     fileprivate var chromeView = UIView()
+    fileprivate var visualEffect: UIVisualEffect?
     fileprivate var keyboardIsShowing: Bool = false
     private var translationStart: CGPoint = CGPoint.zero
     
@@ -127,10 +128,7 @@ class PresentrController: UIPresentationController, UIAdaptivePresentationContro
         chromeView.addGestureRecognizer(tap)
 
         if blurBackground {
-            let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: blurStyle))
-            blurEffectView.frame = chromeView.bounds
-            blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            chromeView.addSubview(blurEffectView)
+            visualEffect = UIBlurEffect(style: blurStyle)
         } else {
             chromeView.backgroundColor = backgroundColor.withAlphaComponent(CGFloat(backgroundOpacity))
         }
@@ -336,14 +334,28 @@ extension PresentrController {
 
     override func presentationTransitionWillBegin() {
         chromeView.frame = containerView!.bounds
-        chromeView.alpha = 0.0
         containerView?.insertSubview(chromeView, at: 0)
+        
+        var blurEffectView: UIVisualEffectView?
+        
+        if visualEffect != nil {
+            let view = UIVisualEffectView()
+            view.frame = chromeView.bounds
+            view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            chromeView.addSubview(view)
+            
+            blurEffectView = view
+        } else {
+            chromeView.alpha = 0.0
+        }
 
         if let coordinator = presentedViewController.transitionCoordinator {
 
             coordinator.animate(alongsideTransition: { context in
+                blurEffectView?.effect = self.visualEffect
                 self.chromeView.alpha = 1.0
-                }, completion: nil)
+
+            }, completion: nil)
 
         } else {
             chromeView.alpha = 1.0

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This can be cumbersome, specially if you do it multiple times in your app. **Pre
 
 ## What's New
 
+#### 1.0.4 
+- Support for animated blurred background (thanks to @fpg1503)
+
 #### 1.0.3
 - Support for custom radius & drop shadow (thanks @falkobuttler)
 - New fluid percentage option for ModalSize enum (thanks @mseijas)


### PR DESCRIPTION
Currently the blur change is abrupt. I used `UIViewControllerTransitionCoordinator`'s `animate(alongsideTransition:, completion:)` to add the visual effect so the radius changes progressively and the animation is smoother.