### PR TITLE
Add support to custom animations

### DIFF
--- a/Presentr/PresentrAnimation.swift
+++ b/Presentr/PresentrAnimation.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  *  Protocol that represents a custom PresentrAnimation. Conforms to 'UIViewControllerAnimatedTransitioning'
  */
-protocol PresentrAnimation: UIViewControllerAnimatedTransitioning {
+public protocol PresentrAnimation: UIViewControllerAnimatedTransitioning {
 
     /// The duration for the animation. Must be set by the class that implements protocol.
     var animationDuration: TimeInterval { get set }

--- a/Presentr/PresentrAnimation.swift
+++ b/Presentr/PresentrAnimation.swift
@@ -28,9 +28,9 @@ public protocol PresentrAnimation: UIViewControllerAnimatedTransitioning {
 }
 
 /// Transform block used to obtain the initial frame for the animation, given the finalFrame and the container's frame.
-typealias FrameTransformer = (_ finalFrame: CGRect, _ containerFrame: CGRect) -> CGRect
+public typealias FrameTransformer = (_ finalFrame: CGRect, _ containerFrame: CGRect) -> CGRect
 
-extension PresentrAnimation {
+public extension PresentrAnimation {
 
     func animate(_ transitionContext: UIViewControllerContextTransitioning, transform: FrameTransformer) {
         let containerView = transitionContext.containerView

--- a/Presentr/TransitionType.swift
+++ b/Presentr/TransitionType.swift
@@ -17,6 +17,7 @@ import Foundation
  - CoverVerticalFromTop:     Custom transition animation. Slides in vertically from top.
  - CoverHorizontalFromLeft:  Custom transition animation. Slides in horizontally from left.
  - CoverHorizontalFromRight: Custom transition animation. Slides in horizontally from  right.
+ - Custom:                   Custom transition animation provided by the user.
  */
 public enum TransitionType {
 

--- a/Presentr/TransitionType.swift
+++ b/Presentr/TransitionType.swift
@@ -28,6 +28,8 @@ public enum TransitionType {
     case coverVerticalFromTop
     case coverHorizontalFromRight
     case coverHorizontalFromLeft
+    // User defined
+    case custom(PresentrAnimation)
 
     /**
      Maps the 'TransitionType' to the system provided transition.
@@ -61,6 +63,8 @@ public enum TransitionType {
             return CoverHorizontalAnimation(fromRight: true)
         case .coverHorizontalFromLeft:
             return CoverHorizontalAnimation(fromRight: false)
+        case .custom(let animation):
+            return animation
         default:
             return nil
         }

--- a/PresentrExample/PresentrExample.xcodeproj/project.pbxproj
+++ b/PresentrExample/PresentrExample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		06A1F0BB1CF3D17E0057C79B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06A1F0BA1CF3D17E0057C79B /* Assets.xcassets */; };
 		06A1F0BE1CF3D17E0057C79B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 06A1F0BC1CF3D17E0057C79B /* LaunchScreen.storyboard */; };
 		25591534D92612E66093237C /* Pods_PresentrExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9985464B38C3FFC83D568727 /* Pods_PresentrExample.framework */; };
+		A3BE60BE1E112CF700CA59D3 /* SpringFromBottomAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BE60BD1E112CF700CA59D3 /* SpringFromBottomAnimation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -42,6 +43,7 @@
 		06A1F0BF1CF3D17E0057C79B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2D9A1F9F4161E3588659C3CF /* Pods-PresentrExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PresentrExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-PresentrExample/Pods-PresentrExample.release.xcconfig"; sourceTree = "<group>"; };
 		9985464B38C3FFC83D568727 /* Pods_PresentrExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PresentrExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A3BE60BD1E112CF700CA59D3 /* SpringFromBottomAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpringFromBottomAnimation.swift; sourceTree = "<group>"; };
 		B37B2AC285D84D58CC7D5CA3 /* Pods-PresentrExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PresentrExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PresentrExample/Pods-PresentrExample.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -82,6 +84,7 @@
 				069265821DD0F9AD00B67915 /* MainTableViewController.swift */,
 				069265841DD12CF400B67915 /* ExampleTableViewCell.swift */,
 				0644CEC01DADCD02002E586F /* PopupViewController.swift */,
+				A3BE60BD1E112CF700CA59D3 /* SpringFromBottomAnimation.swift */,
 				06A1F0B71CF3D17E0057C79B /* Main.storyboard */,
 				06A1F0BA1CF3D17E0057C79B /* Assets.xcassets */,
 				06A1F0BC1CF3D17E0057C79B /* LaunchScreen.storyboard */,
@@ -234,6 +237,7 @@
 			files = (
 				069265831DD0F9AD00B67915 /* MainTableViewController.swift in Sources */,
 				069265851DD12CF400B67915 /* ExampleTableViewCell.swift in Sources */,
+				A3BE60BE1E112CF700CA59D3 /* SpringFromBottomAnimation.swift in Sources */,
 				06A1F0B41CF3D17E0057C79B /* AppDelegate.swift in Sources */,
 				0644CEC11DADCD02002E586F /* PopupViewController.swift in Sources */,
 			);

--- a/PresentrExample/PresentrExample/MainTableViewController.swift
+++ b/PresentrExample/PresentrExample/MainTableViewController.swift
@@ -32,7 +32,7 @@ enum ExampleSection {
         case .bottomHalf:
             return [.bottomHalfDefault, .bottomHalfCustom]
         case .other:
-            return [.backgroundBlur, .fullScreen, .custom, .keyboardTest]
+            return [.backgroundBlur, .fullScreen, .custom, .keyboardTest, .customAnimation]
         }
     }
 
@@ -53,6 +53,7 @@ enum ExampleItem: String {
     case custom = "Custom"
     case keyboardTest = "Test keyboard translation & delegate"
     case backgroundBlur = "Test the background blur animation"
+    case customAnimation = "Custom transition animation"
 
     var action: Selector {
         switch self {
@@ -82,6 +83,8 @@ enum ExampleItem: String {
             return #selector(MainTableViewController.keyboardTranslationTest)
         case .backgroundBlur:
             return #selector(MainTableViewController.backgroundBlurTest)
+        case .customAnimation:
+            return #selector(MainTableViewController.customAnimation)
         }
     }
 
@@ -296,6 +299,12 @@ extension MainTableViewController {
     func backgroundBlurTest() {
         presenter.blurBackground = true
         alertDefault()
+    }
+    
+    func customAnimation() {
+        let springBottom = SpringFromBottomAnimation()
+        presenter.transitionType = .custom(springBottom)
+        customPresentViewController(presenter, viewController: alertController, animated: true, completion: nil)
     }
 
 }

--- a/PresentrExample/PresentrExample/MainTableViewController.swift
+++ b/PresentrExample/PresentrExample/MainTableViewController.swift
@@ -92,13 +92,13 @@ enum ExampleItem: String {
 
 class MainTableViewController: UITableViewController {
 
-    let presenter: Presentr = {
+    func alertPresenter() -> Presentr {
         let presenter = Presentr(presentationType: .alert)
         presenter.transitionType = TransitionType.coverHorizontalFromRight
         return presenter
-    }()
+    }
 
-    let customPresenter: Presentr = {
+    func customPresenter() -> Presentr {
         let width = ModalSize.full
         //let height = ModalSize.custom(size: 150)
         let height = ModalSize.fluid(percentage: 0.20)
@@ -112,7 +112,7 @@ class MainTableViewController: UITableViewController {
         customPresenter.backgroundColor = UIColor.green
         customPresenter.backgroundOpacity = 0.5
         return customPresenter
-    }()
+    }
 
     lazy var alertController: AlertViewController = {
         let alertController = Presentr.alertViewController(title: "Are you sure? ⚠️", body: "This action can't be undone!")
@@ -192,6 +192,8 @@ class MainTableViewController: UITableViewController {
 extension MainTableViewController {
 
     func alertDefault() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .alert
 
         presenter.transitionType = nil
@@ -202,6 +204,7 @@ extension MainTableViewController {
     }
 
     func alertCustom() {
+        let presenter = alertPresenter()
         presenter.presentationType = .alert
 
         presenter.transitionType = .coverHorizontalFromLeft
@@ -212,12 +215,16 @@ extension MainTableViewController {
     }
 
     func alertDefaultWithoutAnimation() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .alert
         presenter.dismissAnimated = false
         customPresentViewController(presenter, viewController: alertController, animated: false, completion: nil)
     }
 
     func popupDefault() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .popup
 
         presenter.transitionType = nil
@@ -228,6 +235,8 @@ extension MainTableViewController {
     }
 
     func popupCustom() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .popup
 
         presenter.transitionType = .coverHorizontalFromRight
@@ -238,6 +247,8 @@ extension MainTableViewController {
     }
 
     func topHalfDefault() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .topHalf
 
         presenter.transitionType = nil
@@ -248,6 +259,8 @@ extension MainTableViewController {
     }
 
     func topHalfCustom() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .topHalf
 
         presenter.transitionType = .coverHorizontalFromLeft
@@ -258,6 +271,8 @@ extension MainTableViewController {
     }
 
     func bottomHalfDefault() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .bottomHalf
 
         presenter.transitionType = nil
@@ -268,6 +283,8 @@ extension MainTableViewController {
     }
 
     func bottomHalfCustom() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .bottomHalf
 
         presenter.transitionType = .coverHorizontalFromLeft
@@ -278,10 +295,14 @@ extension MainTableViewController {
     }
 
     func customPresentation() {
-        customPresentViewController(customPresenter, viewController: alertController, animated: true, completion: nil)
+        let presenter = customPresenter()
+        
+        customPresentViewController(presenter, viewController: alertController, animated: true, completion: nil)
     }
 
     func fullScreenPresentation() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .fullScreen
 
         presenter.transitionType = .coverVertical
@@ -291,18 +312,24 @@ extension MainTableViewController {
     }
 
     func keyboardTranslationTest() {
+        let presenter = alertPresenter()
+        
         presenter.presentationType = .popup
         presenter.keyboardTranslationType = .compress
         customPresentViewController(presenter, viewController: popupViewController, animated: true, completion: nil)
     }
 
     func backgroundBlurTest() {
+        let presenter = alertPresenter()
+        
         presenter.blurBackground = true
         alertDefault()
     }
     
     func customAnimation() {
+        let presenter = alertPresenter()
         let springBottom = SpringFromBottomAnimation()
+        
         presenter.transitionType = .custom(springBottom)
         customPresentViewController(presenter, viewController: alertController, animated: true, completion: nil)
     }

--- a/PresentrExample/PresentrExample/SpringFromBottomAnimation.swift
+++ b/PresentrExample/PresentrExample/SpringFromBottomAnimation.swift
@@ -1,0 +1,88 @@
+//
+//  SpringFromBottomAnimation.swift
+//  PresentrExample
+//
+//  Created by Francesco Perrotti-Garcia on 12/26/16.
+//  Copyright © 2016 Presentr. All rights reserved.
+//
+
+import UIKit
+import Presentr
+
+class SpringFromBottomAnimation: NSObject, PresentrAnimation {
+    
+    var animationDuration: TimeInterval
+    
+    fileprivate var springDamping: CGFloat
+    fileprivate var initialSpringVelocity: CGFloat
+    
+    init(animationDuration: TimeInterval = 0.5,
+         springDamping: CGFloat = 0.5,
+         initialSpringVelocity: CGFloat = 0) {
+        self.animationDuration = animationDuration
+        self.springDamping = springDamping
+        self.initialSpringVelocity = initialSpringVelocity
+    }
+    
+    func animate(_ transitionContext: UIViewControllerContextTransitioning, transform: FrameTransformer) {
+        let containerView = transitionContext.containerView
+        
+        let fromViewController = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.from)
+        let toViewController = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to)
+        let fromView = transitionContext.view(forKey: UITransitionContextViewKey.from)
+        let toView = transitionContext.view(forKey: UITransitionContextViewKey.to)
+        
+        let isPresenting: Bool = (toViewController?.presentingViewController == fromViewController)
+        
+        let animatingVC = isPresenting ? toViewController : fromViewController
+        let animatingView = isPresenting ? toView : fromView
+        
+        let finalFrameForVC = transitionContext.finalFrame(for: animatingVC!)
+        let initialFrameForVC = transform(finalFrameForVC, containerView.frame)
+        
+        let initialFrame = isPresenting ? initialFrameForVC : finalFrameForVC
+        let finalFrame = isPresenting ? finalFrameForVC : initialFrameForVC
+        
+        let duration = transitionDuration(using: transitionContext)
+        
+        if isPresenting {
+            containerView.addSubview(toView!)
+        }
+        
+        animatingView?.frame = initialFrame
+        
+        UIView.animate(withDuration: duration, delay: 0, usingSpringWithDamping: springDamping, initialSpringVelocity: initialSpringVelocity, options: .allowUserInteraction, animations: {
+            
+            animatingView?.frame = finalFrame
+            
+        }, completion: { (value: Bool) in
+            
+            if !isPresenting {
+                fromView?.removeFromSuperview()
+            }
+            
+            let wasCancelled = transitionContext.transitionWasCancelled
+            transitionContext.completeTransition(!wasCancelled)
+            
+        })
+    }
+}
+
+// MARK: UIViewControllerAnimatedTransitioning
+
+extension SpringFromBottomAnimation: UIViewControllerAnimatedTransitioning {
+    
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return animationDuration
+    }
+    
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        animate(transitionContext) { finalFrame, containerFrame in
+            var initialFrame = finalFrame
+            initialFrame.origin.y = containerFrame.size.height + initialFrame.size.height
+            return initialFrame
+        }
+    }
+    
+}
+


### PR DESCRIPTION
I made `PresentrAnimation` public to add support to custom animations but I realized that most of the logic inside the `animate` extension is duplicated. Do you think the animation itself should be externalized in a closure/function considering the rest is most likely boilerplate and will rarely change?

I added an example of custom animation using an animation from the bottom with spring effect.