### PR TITLE
Added important detail about the use of keyboardTranslationType property

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ presenter.dismissOnSwipe = true
 presenter.dismissOnSwipeDirection = .top
 ```
 
-If you have text fields inside your modal and the PresentationType is set to popup, you can use a **KeyboardTranslationType** to tell **Presentr** how to handle your modal when the keyboard shows up.
+If you have text fields inside your modal and the presentationType property is set to popup, you can use a **KeyboardTranslationType** to tell **Presentr** how to handle your modal when the keyboard shows up.
 
 ```swift
 presenter.keyboardTranslationType = .none

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ presenter.dismissOnSwipe = true
 presenter.dismissOnSwipeDirection = .top
 ```
 
-If you have text fields inside your modal, you can use a **KeyboardTranslationType** to tell **Presentr** how to handle your modal when the keyboard shows up.
+If you have text fields inside your modal and the PresentationType is set to popup, you can use a **KeyboardTranslationType** to tell **Presentr** how to handle your modal when the keyboard shows up.
 
 ```swift
 presenter.keyboardTranslationType = .none


### PR DESCRIPTION
Here https://github.com/IcaliaLabs/Presentr/blob/60f3e0b79cbaaa3bb2aa2abe412a4aff458f7230/Presentr/PresentrController.swift#L47 I noticed that the only case that keyboardTranslationType will work is if **PresentationType.modal** is used as presentationType. I updated the docs to point that important detail.