### PR TITLE
Resolve compiler error in Xcode 9 beta 2

### DIFF
--- a/Presentr/AlertViewController.swift
+++ b/Presentr/AlertViewController.swift
@@ -247,15 +247,7 @@ extension AlertViewController {
             return false
         }
 
-        #if swift(>=3.2)
-            guard let font = CGFont(provider) else {
-                print("Error loading font. Could not create CGFont from CGDataProvider.")
-                return false
-            }
-        #else
-            let font = CGFont(provider)
-        #endif
-
+        let font = CGFont(provider)
         var error: Unmanaged<CFError>?
 
         let success = CTFontManagerRegisterGraphicsFont(font, &error)

--- a/Presentr/PresentationType.swift
+++ b/Presentr/PresentationType.swift
@@ -42,7 +42,7 @@ public enum PresentationType {
             return (.full, .full)
         case .custom(let width, let height, _):
             return (width, height)
-        case .dynamic:
+        case .dynamic(_):
             return nil
         }
     }


### PR DESCRIPTION
Xcode 9 beta two complains that the switch cases are not exhaustive. Adding the `.dynamic` case's associated value fixes the issue.

This change is backwards compatible with Xcode 8.