### PR TITLE
Add swift_version to spec

### DIFF
--- a/Presentr.podspec
+++ b/Presentr.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.author       = { "Daniel Lozano" => "dan@danielozano.com" }
   s.social_media_url   = "http://twitter.com/danlozanov"
   s.platform     = :ios, "8.0"
+  s.swift_version = "4.0"
   s.source       = { :git => "https://github.com/icalialabs/Presentr.git", :tag => "1.3" }
   s.source_files = "Presentr/**/*.{swift}"
   s.resources    = "Presentr/**/*.{xib,ttf}"


### PR DESCRIPTION
### What does this PR do?

* Specifies the swift version that will be used for the pod regardless of the swift version the app target uses.

Note: This feature was added on CocoaPods 1.4.0 (http://blog.cocoapods.org/CocoaPods-1.4.0/)
