### PR TITLE
Add exception for 20 pt buffer

### DIFF
--- a/Presentr/KeyboardTranslation.swift
+++ b/Presentr/KeyboardTranslation.swift
@@ -25,7 +25,8 @@ public enum KeyboardTranslationType {
      */
     public func getTranslationFrame(keyboardFrame: CGRect, presentedFrame: CGRect) -> CGRect {
         let keyboardTop = UIScreen.main.bounds.height - keyboardFrame.size.height
-        let presentedViewBottom = presentedFrame.origin.y + presentedFrame.height + 20.0 // add a 20 pt buffer
+        let buffer: CGFloat = (presentedFrame.origin.y + presentedFrame.size.height == UIScreen.main.bounds.height) ? 0 : 20.0 // add a 20 pt buffer except when the presentedFrame is stick to bottom
+        let presentedViewBottom = presentedFrame.origin.y + presentedFrame.height + buffer
         let offset = presentedViewBottom - keyboardTop
         switch self {
         case .moveUp:


### PR DESCRIPTION
20 pt buffer is not necessary if the original frame is designed to stick to the bottom of screen or anything.

### What does this PR do?

* Check if the presentedFrame is stick to the screen bottom, if true, set 0 buffer.
