### PR TITLE
Supported left & right directions for DismissSwipeDirection

### DIFF
--- a/Presentr/Presentr.swift
+++ b/Presentr/Presentr.swift
@@ -25,6 +25,8 @@ public enum DismissSwipeDirection {
     case `default`
     case bottom
     case top
+    case left
+    case right
 }
 
 /// The action that should happen when the background is tapped.

--- a/Presentr/PresentrController.swift
+++ b/Presentr/PresentrController.swift
@@ -439,6 +439,11 @@ extension PresentrController {
         let amount = gesture.translation(in: presentedViewController.view)
         
         if dismissOnSwipeDirection == .left || dismissOnSwipeDirection == .right {
+            if dismissOnSwipeDirection == .left && amount.x > 0 {
+                return
+            } else if dismissOnSwipeDirection == .right && amount.x < 0 {
+                return
+            }
             let swipeLimit: CGFloat = dismissOnSwipeDirection == .left ? -50 : 50
             presentedViewController.view.center = CGPoint(x: presentedViewCenter.x + amount.x, y: presentedViewCenter.y)
             let dismiss = dismissOnSwipeDirection == .left ? (amount.x < swipeLimit) : (amount.x > swipeLimit)

--- a/Presentr/PresentrController.swift
+++ b/Presentr/PresentrController.swift
@@ -446,25 +446,25 @@ extension PresentrController {
                 presentedViewIsBeingDissmissed = true
                 presentedViewController.dismiss(animated: dismissAnimated, completion: nil)
             }
-        }
+        } else {
+            if shouldSwipeTop && amount.y > 0 {
+                return
+            } else if shouldSwipeBottom && amount.y < 0 {
+                return
+            }
 
-        if shouldSwipeTop && amount.y > 0 {
-            return
-        } else if shouldSwipeBottom && amount.y < 0 {
-            return
-        }
+            var swipeLimit: CGFloat = 100
+            if shouldSwipeTop {
+                swipeLimit = -swipeLimit
+            }
 
-        var swipeLimit: CGFloat = 100
-        if shouldSwipeTop {
-            swipeLimit = -swipeLimit
-        }
+            presentedViewController.view.center = CGPoint(x: presentedViewCenter.x, y: presentedViewCenter.y + amount.y)
 
-        presentedViewController.view.center = CGPoint(x: presentedViewCenter.x, y: presentedViewCenter.y + amount.y)
-
-        let dismiss = shouldSwipeTop ? (amount.y < swipeLimit) : ( amount.y > swipeLimit)
-        if dismiss && latestShouldDismiss {
-            presentedViewIsBeingDissmissed = true
-            presentedViewController.dismiss(animated: dismissAnimated, completion: nil)
+            let dismiss = shouldSwipeTop ? (amount.y < swipeLimit) : ( amount.y > swipeLimit)
+            if dismiss && latestShouldDismiss {
+                presentedViewIsBeingDissmissed = true
+                presentedViewController.dismiss(animated: dismissAnimated, completion: nil)
+            }
         }
     }
 


### PR DESCRIPTION
Currently `DismissSwipeDirection` enum only vertical directions: `top` & `bottom`. There're some use cases where the view controller is presented from the left\right: `presentr.transitionType = .coverHorizontalFromLeft`. We should support horizontal gesture of  `DismissSwipeDirection` as well.