### PR TITLE
Add support for left + right on DismissSwipeDirection

### DIFF
--- a/Presentr/Presentr.swift
+++ b/Presentr/Presentr.swift
@@ -94,6 +94,9 @@ public class Presentr: NSObject {
 
     /// Should the presented controller use animation when dismiss on background tap or swipe. Default is true.
     public var dismissAnimated = true
+    
+    /// How much the presented controller should resist being dragged in the opposite direction (1 is max, 0 is no resistance).
+    public var overdragResistanceFactor: Float?
 
     /// Color of the background. Default is Black.
     public var backgroundColor = UIColor.black
@@ -191,6 +194,7 @@ extension Presentr: UIViewControllerTransitioningDelegate {
                                     dismissOnSwipe: dismissOnSwipe,
                                     dismissOnSwipeDirection: dismissOnSwipeDirection,
                                     dismissOnRelease: dismissOnRelease,
+                                    overdragResistanceFactor: overdragResistanceFactor,
                                     backgroundColor: backgroundColor,
                                     backgroundOpacity: backgroundOpacity,
                                     blurBackground: blurBackground,

--- a/Presentr/Presentr.swift
+++ b/Presentr/Presentr.swift
@@ -23,8 +23,10 @@ public enum PresentrConstants {
 
 public enum DismissSwipeDirection {
     case `default`
-    case bottom
     case top
+    case bottom
+    case left
+    case right
 }
 
 /// The action that should happen when the background is tapped.

--- a/Presentr/Presentr.swift
+++ b/Presentr/Presentr.swift
@@ -88,6 +88,9 @@ public class Presentr: NSObject {
 
     /// If dismissOnSwipe is true, the direction for the swipe. Default depends on presentation type.
     public var dismissOnSwipeDirection: DismissSwipeDirection = .default
+    
+    /// Should the presented controller be dismissed when the gesture is ended (e.g. the user lifts their finger from the screen). Default is false
+    public var dismissOnRelease = false
 
     /// Should the presented controller use animation when dismiss on background tap or swipe. Default is true.
     public var dismissAnimated = true
@@ -187,6 +190,7 @@ extension Presentr: UIViewControllerTransitioningDelegate {
                                     backgroundTap: backgroundTap,
                                     dismissOnSwipe: dismissOnSwipe,
                                     dismissOnSwipeDirection: dismissOnSwipeDirection,
+                                    dismissOnRelease: dismissOnRelease,
                                     backgroundColor: backgroundColor,
                                     backgroundOpacity: backgroundOpacity,
                                     blurBackground: blurBackground,

--- a/Presentr/PresentrController.swift
+++ b/Presentr/PresentrController.swift
@@ -88,18 +88,6 @@ class PresentrController: UIPresentationController, UIAdaptivePresentationContro
 
     fileprivate var presentedViewCenter: CGPoint = .zero
 
-    fileprivate var latestShouldDismiss: Bool = true
-
-    fileprivate lazy var shouldSwipeBottom: Bool = {
-		let defaultDirection = dismissOnSwipeDirection == .default
-        return defaultDirection ? presentationType != .topHalf : dismissOnSwipeDirection == .bottom
-    }()
-
-    fileprivate lazy var shouldSwipeTop: Bool = {
-		let defaultDirection = dismissOnSwipeDirection == .default
-        return defaultDirection ? presentationType == .topHalf : dismissOnSwipeDirection == .top
-    }()
-
     // MARK: - Init
 
     init(presentedViewController: UIViewController,
@@ -427,11 +415,6 @@ extension PresentrController {
         if gesture.state == .began {
             presentedViewFrame = presentedViewController.view.frame
             presentedViewCenter = presentedViewController.view.center
-
-            let directionDown = gesture.translation(in: presentedViewController.view).y > 0
-            if (shouldSwipeBottom && directionDown) || (shouldSwipeTop && !directionDown) {
-                latestShouldDismiss = conformingPresentedController?.presentrShouldDismiss?(keyboardShowing: keyboardIsShowing) ?? true
-            }
         } else if gesture.state == .changed {
             swipeGestureChanged(gesture: gesture)
         } else if gesture.state == .ended || gesture.state == .cancelled {

--- a/Presentr/PresentrController.swift
+++ b/Presentr/PresentrController.swift
@@ -474,8 +474,6 @@ extension PresentrController {
 
         var shouldDismiss = false
         
-        print(amount, presentedViewFrame.height)
-        
         switch dismissOnSwipeDirection {
         case .top:
             if amount.y > 0 {


### PR DESCRIPTION
### What does this PR do?

* Add support for `.left` and `.right` to `DismissSwipeDirection`
* Add `dismissOnRelease` dismiss presented view on gesture ended (like a traditional `UIViewController`)
* Uses `swipedAmount > 50% of VC` rather than `swipeLimit = 100`
  * Also adds support for velocity-based dismissal, for when you quickly swipe the view away, but don't make it to the 50% limit
* Add support for `overdragResistanceFactor` (see https://github.com/IcaliaLabs/Presentr/issues/163)